### PR TITLE
[13.0][FIX] mrp_unbuild_valuation: price unit assignment improvement

### DIFF
--- a/mrp_unbuild_valuation/__manifest__.py
+++ b/mrp_unbuild_valuation/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.2.0.0",
+    "version": "13.0.2.0.1",
     "category": "Manufacturing",
     "website": "https://github.com/solvosci/slv-manufacture",
     "depends": ["mrp", "stock_account"],


### PR DESCRIPTION
This fix makes a better produce move unit price assigment, so lets Odoo process to be used instead of making our own further adjustments on stock valuation layers. This approach also lets Odoo AVCO update in Odoo way.