### PR TITLE
[13.0][IMP] stock_valuation_mrp: AVCO calc from total_quantity to stock_quantity

### DIFF
--- a/stock_valuation_mrp/__manifest__.py
+++ b/stock_valuation_mrp/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.0.0",
+    "version": "13.0.2.0.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": ["stock_valuation", "mrp_unbuild_advanced"],


### PR DESCRIPTION
With this major change, AVCO calculation is changed, corresponding with the same major change in stock_valuation.

In MRP operations only affects to unbuild "back to draft" option. With this improvement, unlinking SVLs also affects to original unbuild consumed product, because its stock has changed, and AVCO value is changed too.

Depends on solvosci/slv-stock#52

cc @ChristianSantamaria 