### PR TITLE
[13.0][IMP] stock_valuation_mrp: increased quantity precision for unbuilds

### DIFF
--- a/stock_valuation_mrp/__manifest__.py
+++ b/stock_valuation_mrp/__manifest__.py
@@ -7,10 +7,10 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.2.0.0",
+    "version": "13.0.2.1.0",
     "category": "stock",
     "website": "https://github.com/solvosci/slv-stock",
     "depends": ["stock_valuation", "mrp_unbuild_advanced"],
-    "data": [],
+    "data": ["views/mrp_unbuild_views.xml"],
     'installable': True,
 }

--- a/stock_valuation_mrp/views/mrp_unbuild_views.xml
+++ b/stock_valuation_mrp/views/mrp_unbuild_views.xml
@@ -1,0 +1,24 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+    <record id="mrp_unbuild_tree_view" model="ir.ui.view">
+        <field name="name">mrp.unbuild.tree (in stock_valuation_mrp)</field>
+        <field name="model">mrp.unbuild</field>
+        <field name="inherit_id" ref="mrp.mrp_unbuild_tree_view"/>
+        <field name="arch" type="xml">
+            <field name="product_qty" position="attributes">
+                <attribute name="digits">[12,3]</attribute>
+            </field>
+        </field>
+    </record>
+
+    <record id="mrp_unbuild_form_view" model="ir.ui.view">
+        <field name="name">mrp.unbuild.form (in stock_valuation_mrp)</field>
+        <field name="model">mrp.unbuild</field>
+        <field name="inherit_id" ref="mrp.mrp_unbuild_form_view"/>
+        <field name="arch" type="xml">
+            <field name="product_qty" position="attributes">
+                <attribute name="digits">[12,3]</attribute>
+            </field>
+        </field>
+    </record>
+</odoo>


### PR DESCRIPTION
For stock valuation features and unbuilds, better 3 decimals than default (usually 2).

The best approach should be adding `digits="Product Unit of Measure"` (Odoo standard does not include this, it's weird) for product quantity, but a simply view improvement also works for us.

cc @ChristianSantamaria 