### PR TITLE
[14.0][FIX] mrp_timesheet_link: secure ``cancel()`` access

### DIFF
--- a/mrp_timesheet_link/__manifest__.py
+++ b/mrp_timesheet_link/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "14.0.1.0.0",
+    "version": "14.0.1.0.1",
     "category": "Inventory/Purchase",
     "website": "https://github.com/solvosci/slv-manufacture",
     "depends": ["hr_timesheet", "mrp"],

--- a/mrp_timesheet_link/models/mrp_production.py
+++ b/mrp_timesheet_link/models/mrp_production.py
@@ -48,8 +48,9 @@ class MRPProduction(models.Model):
 
     def action_cancel(self):
         res = super(MRPProduction, self).action_cancel()
-        if self.task_id:
-            self.project_id = False
-            self.task_id.production_id = False
-            self.task_id = False
+        self_sudo = self.sudo()
+        if self_sudo.task_id:
+            self_sudo.project_id = False
+            self_sudo.task_id.production_id = False
+            self_sudo.task_id = False
         return res


### PR DESCRIPTION
A cancellation by a user without project access should raise a permissions error. This fix it