### PR TITLE
[13.0][IMP] mrp_unbuild_advanced: shift data replacement in unbuild form view

### DIFF
--- a/mrp_unbuild_advanced/__manifest__.py
+++ b/mrp_unbuild_advanced/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.2.2.0",
+    "version": "13.0.2.3.0",
     "category": "Manufacturing",
     "website": "https://github.com/solvosci/slv-manufacture",
     "depends": ["mrp_tag", "stock_move_action_done_custdate"],

--- a/mrp_unbuild_advanced/i18n/es.po
+++ b/mrp_unbuild_advanced/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-29 18:32+0000\n"
-"PO-Revision-Date: 2021-11-29 18:32+0000\n"
+"POT-Creation-Date: 2024-04-16 06:59+0000\n"
+"PO-Revision-Date: 2024-04-16 06:59+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -34,6 +34,11 @@ msgstr "Fin"
 #: model:ir.model.fields,field_description:mrp_unbuild_advanced.field_mrp_unbuild__notes
 msgid "Notes"
 msgstr "Observaciones"
+
+#. module: mrp_unbuild_advanced
+#: model:ir.model.fields,field_description:mrp_unbuild_advanced.field_mrp_unbuild__scheduled_time
+msgid "Scheduled Time"
+msgstr "Tiempo programado"
 
 #. module: mrp_unbuild_advanced
 #: model:ir.model.fields,field_description:mrp_unbuild_advanced.field_mrp_unbuild__shift_break_time
@@ -69,7 +74,9 @@ msgstr "Datos del turno"
 #: code:addons/mrp_unbuild_advanced/models/mrp_unbuild.py:0
 #, python-format
 msgid "Shift dates must be filled before unbuild action for %s is performed!"
-msgstr "¡Las fechas del turno tienen que estar cubiertas antes ejecutar la acción de despiezar para %s!"
+msgstr ""
+"¡Las fechas del turno tienen que estar cubiertas antes ejecutar la acción de"
+" despiezar para %s!"
 
 #. module: mrp_unbuild_advanced
 #: code:addons/mrp_unbuild_advanced/models/mrp_unbuild.py:0
@@ -90,7 +97,7 @@ msgstr "Inicio"
 #. module: mrp_unbuild_advanced
 #: model:ir.model,name:mrp_unbuild_advanced.model_stock_move
 msgid "Stock Move"
-msgstr "Movimiento de Inventario"
+msgstr "Movimiento de existencias"
 
 #. module: mrp_unbuild_advanced
 #: model_terms:ir.ui.view,arch_db:mrp_unbuild_advanced.mrp_unbuild_form_view_user
@@ -117,7 +124,7 @@ msgstr "Fecha de despiece"
 #. module: mrp_unbuild_advanced
 #: model:ir.model,name:mrp_unbuild_advanced.model_mrp_unbuild
 msgid "Unbuild Order"
-msgstr "Orden de Desconstrucción"
+msgstr "Orden de desconstrucción"
 
 #. module: mrp_unbuild_advanced
 #: code:addons/mrp_unbuild_advanced/models/mrp_unbuild.py:0

--- a/mrp_unbuild_advanced/i18n/mrp_unbuild_advanced.pot
+++ b/mrp_unbuild_advanced/i18n/mrp_unbuild_advanced.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2021-11-29 18:29+0000\n"
-"PO-Revision-Date: 2021-11-29 18:29+0000\n"
+"POT-Creation-Date: 2024-04-16 06:59+0000\n"
+"PO-Revision-Date: 2024-04-16 06:59+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -33,6 +33,11 @@ msgstr ""
 #. module: mrp_unbuild_advanced
 #: model:ir.model.fields,field_description:mrp_unbuild_advanced.field_mrp_unbuild__notes
 msgid "Notes"
+msgstr ""
+
+#. module: mrp_unbuild_advanced
+#: model:ir.model.fields,field_description:mrp_unbuild_advanced.field_mrp_unbuild__scheduled_time
+msgid "Scheduled Time"
 msgstr ""
 
 #. module: mrp_unbuild_advanced

--- a/mrp_unbuild_advanced/models/mrp_unbuild.py
+++ b/mrp_unbuild_advanced/models/mrp_unbuild.py
@@ -31,6 +31,7 @@ class MrpUnbuild(models.Model):
         states={"draft": [("required", False)], "done": [("required", True)]},
     )
     shift_stop_time = fields.Float()
+    scheduled_time = fields.Float(default=8)
 
     notes = fields.Text()
 
@@ -38,6 +39,13 @@ class MrpUnbuild(models.Model):
         string="Tags",
         comodel_name="mrp.tag",
     )
+
+    @api.onchange("shift_start_date", "shift_end_date")
+    def _onchange_shift_start_date_shift_end_date(self):
+        if self.shift_end_date and self.shift_start_date:
+            self.shift_total_time = (self.shift_end_date - self.shift_start_date).total_seconds() / 60 / 60
+        else:
+            self.shift_total_time = 0
 
     @api.constrains("unbuild_date")
     def _check_unbuild_date(self):

--- a/mrp_unbuild_advanced/views/mrp_unbuild_views.xml
+++ b/mrp_unbuild_advanced/views/mrp_unbuild_views.xml
@@ -51,6 +51,10 @@
                     </group>
                     <group>
                         <field
+                            name="scheduled_time"
+                            widget="float_time"
+                        />
+                        <field
                             name="shift_total_time"
                             widget="float_time"
                             string="Shift time"

--- a/mrp_unbuild_advanced/views/mrp_unbuild_views.xml
+++ b/mrp_unbuild_advanced/views/mrp_unbuild_views.xml
@@ -38,7 +38,7 @@
                     options="{'color_field': 'color', 'no_create_edit': True}"
                 />
             </xpath>
-            <xpath expr="sheet" position="inside">
+            <xpath expr="//field[@name='mo_id']/../.." position="after">
                 <group
                     name="group_shift"
                     attrs="{'invisible': [('id','=',False)]}"


### PR DESCRIPTION
With this improvement Shift Data is placed immediately after the last unbuild main fields group for `form` view.

Other addons of `slv-manufacture` add more information here, and shift data was moved to the end of the form, situation that we can prevent with this improvement

@adriresu with this improvement you can directly remove `mrp_unbuild_form_group_shift_mrp_unbuild_cust_alu_analytics` view from #53 and no more translations issue will arise.

cc @ChristianSantamaria 