### PR TITLE
[13.0][FIX] mrp_unbuild_bom_cust_qty: ignore service products when unbuild is done

### DIFF
--- a/mrp_unbuild_bom_cust_qty/__manifest__.py
+++ b/mrp_unbuild_bom_cust_qty/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.2.0.0",
+    "version": "13.0.2.0.1",
     "category": "Manufacturing",
     "website": "https://github.com/solvosci/slv-manufacture",
     "depends": ["mrp"],


### PR DESCRIPTION
This fix affect to a general bug in Odoo (that already enable adding services to a BoM, and thus, create stock moves with them once unbuild is finished), but also another generated by this addon, for custom BoM lines added by users for a certain unbuild.

cc @ChristianSantamaria 