### PR TITLE
[13.0][IMP] mrp_unbuild_qc: related unbuild product support

### DIFF
--- a/mrp_unbuild_qc/__manifest__.py
+++ b/mrp_unbuild_qc/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.2.0.0",
+    "version": "13.0.2.1.0",
     "category": "Manufacturing",
     "website": "https://github.com/solvosci/slv-manufacture",
     "depends": ["quality_control_mrp_oca"],

--- a/mrp_unbuild_qc/i18n/es.po
+++ b/mrp_unbuild_qc/i18n/es.po
@@ -6,14 +6,16 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-06 17:44+0000\n"
-"PO-Revision-Date: 2024-03-06 17:44+0000\n"
+"POT-Creation-Date: 2024-04-22 14:24+0000\n"
+"PO-Revision-Date: 2024-04-22 16:25+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
+"Language: es\n"
 "MIME-Version: 1.0\n"
 "Content-Type: text/plain; charset=UTF-8\n"
-"Content-Transfer-Encoding: \n"
+"Content-Transfer-Encoding: 8bit\n"
 "Plural-Forms: \n"
+"X-Generator: Poedit 3.0.1\n"
 
 #. module: mrp_unbuild_qc
 #: model:ir.actions.act_window,name:mrp_unbuild_qc.action_qc_inspection_unbuild_all
@@ -64,6 +66,18 @@ msgstr "Movimientos de Producto (Líneas de movimiento)"
 #: model:ir.model,name:mrp_unbuild_qc.model_qc_inspection
 msgid "Quality control inspection"
 msgstr "Inspección del control de calidad"
+
+#. module: mrp_unbuild_qc
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_qc.qc_inspection_form_view_unbuild_qc
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_qc.qc_inspection_search_view_unbuild_qc
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_qc.qc_inspection_tree_view_unbuild_qc
+msgid "Rel. Unbuild Prod."
+msgstr "Prod. rel. despiece"
+
+#. module: mrp_unbuild_qc
+#: model:ir.model.fields,field_description:mrp_unbuild_qc.field_qc_inspection__rel_unbuild_product_id
+msgid "Related unbuild product"
+msgstr "Producto relacionado del despiece"
 
 #. module: mrp_unbuild_qc
 #: model:ir.model.fields,field_description:mrp_unbuild_qc.field_qc_inspection__unbuild_id

--- a/mrp_unbuild_qc/i18n/mrp_unbuild_qc.pot
+++ b/mrp_unbuild_qc/i18n/mrp_unbuild_qc.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-03-06 17:43+0000\n"
-"PO-Revision-Date: 2024-03-06 17:43+0000\n"
+"POT-Creation-Date: 2024-04-22 14:23+0000\n"
+"PO-Revision-Date: 2024-04-22 14:23+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -63,6 +63,18 @@ msgstr ""
 #. module: mrp_unbuild_qc
 #: model:ir.model,name:mrp_unbuild_qc.model_qc_inspection
 msgid "Quality control inspection"
+msgstr ""
+
+#. module: mrp_unbuild_qc
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_qc.qc_inspection_form_view_unbuild_qc
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_qc.qc_inspection_search_view_unbuild_qc
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_qc.qc_inspection_tree_view_unbuild_qc
+msgid "Rel. Unbuild Prod."
+msgstr ""
+
+#. module: mrp_unbuild_qc
+#: model:ir.model.fields,field_description:mrp_unbuild_qc.field_qc_inspection__rel_unbuild_product_id
+msgid "Related unbuild product"
 msgstr ""
 
 #. module: mrp_unbuild_qc

--- a/mrp_unbuild_qc/models/qc_inspection.py
+++ b/mrp_unbuild_qc/models/qc_inspection.py
@@ -11,6 +11,23 @@ class QcInspection(models.Model):
         comodel_name="mrp.unbuild",
         readonly=True,
     )
+    rel_unbuild_product_id = fields.Many2one(
+        comodel_name="product.product",
+        compute="_compute_rel_unbuild_product_id",
+        store=True,
+        readonly=True,
+        states={"draft": [("readonly", False)]},
+        string="Related unbuild product",
+    )
+
+    @api.depends("unbuild_id", "object_id")
+    def _compute_rel_unbuild_product_id(self):
+        for inspection in self.filtered(lambda x: (
+            x.unbuild_id
+            and x.object_id
+            and x.object_id._name == "stock.move"
+        )):
+            inspection.rel_unbuild_product_id = inspection.object_id.product_id
 
     @api.depends("unbuild_id")
     def _compute_product_id(self):

--- a/mrp_unbuild_qc/views/qc_inspection_views.xml
+++ b/mrp_unbuild_qc/views/qc_inspection_views.xml
@@ -14,6 +14,11 @@
             </xpath>
             <xpath expr="//field[@name='qty']" position="after">
                 <field name="unbuild_id" />
+                <field
+                    name="rel_unbuild_product_id"
+                    string="Rel. Unbuild Prod."
+                    attrs="{'invisible': [('unbuild_id', '=', False)]}"
+                />
             </xpath>
         </field>
     </record>
@@ -29,6 +34,12 @@
                     invisible="context.get('hide_unbuild', False)"
                 />
             </xpath>
+            <xpath expr="//field[@name='product_id']" position="after">
+                <field
+                    name="rel_unbuild_product_id"
+                    string="Rel. Unbuild Prod."
+                />
+            </xpath>
         </field>
     </record>
 
@@ -39,6 +50,7 @@
         <field name="arch" type="xml">
             <xpath expr="//field[@name='product_id']" position="after">
                 <field name="unbuild_id" />
+                <field name="rel_unbuild_product_id" />
             </xpath>
             <xpath expr="//filter[@name='incorrect']" position="after">
                 <separator/>
@@ -54,6 +66,12 @@
                     name="group_by_unbuild_id"
                     domain="[]"
                     context="{'group_by': 'unbuild_id'}"
+                />
+                <filter
+                    string="Rel. Unbuild Prod."
+                    name="group_by_rel_unbuild_product_id"
+                    domain="[]"
+                    context="{'group_by': 'rel_unbuild_product_id'}"
                 />
             </xpath>
         </field>


### PR DESCRIPTION
With this improvement, an additional product for a QC inspection is added and can be manually stablished and/or automatically filled depending on linked stock move.
This could be useful for those inspections programmatically created and not yet linked to an unbuild stock move (e.g. when unbuild is still in a draft state).

@adriresu now it's possible linking to custom unbuild product component in `mrp_unbuild_cust_alu_analytics` during inspection import process, simply adding `rel_unbuild_product_id` value calling `create()` method for `qc.inspection`, could you try? cc @ChristianSantamaria 