### PR TITLE
[13.0][IMP] mrp_unbuild_cust_alu_analytics: ignore unbuild no-named .xml analytics

### DIFF
--- a/mrp_unbuild_cust_alu_analytics/__manifest__.py
+++ b/mrp_unbuild_cust_alu_analytics/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "AGPL-3",
-    "version": "13.0.1.5.0",
+    "version": "13.0.1.6.0",
     "category": "Manufacturing",
     "website": "https://github.com/solvosci/slv-manufacture",
     "depends": ["mrp_unbuild_advanced", "mrp_unbuild_bom_cust_qty", "report_xlsx", "mrp_unbuild_qc", "mrp_unbuild_bom_cust_qty"],

--- a/mrp_unbuild_cust_alu_analytics/models/mrp_unbuild.py
+++ b/mrp_unbuild_cust_alu_analytics/models/mrp_unbuild.py
@@ -151,9 +151,21 @@ class MrpUnbuild(models.Model):
                         # Move file to processed folder
                         os.rename("%s/%s" % (path, file), os.path.join(processed_folder_path + '/' + file))
                     else:
-                        logger.error(
-                            "Can't find unbuild with name: <%s>", unbuild_name
-                        )
+                        # When unbuild is not found, there are two possibilities:
+                        # - No name found => it's a test analytic, so it should
+                        #   be marked as processed, like a right one
+                        # - Incorrect unbuild name => it should be kept as
+                        #   unprocessed, so external users can check it and fix the problem
+                        # TODO os.rename reuse => move to a function
+                        if not unbuild_name:
+                            os.rename("%s/%s" % (path, file), os.path.join(processed_folder_path + '/' + file))
+                            logger.warning(
+                                "Analytic file <%s> with no unbuild name moved to processed folder", file
+                            )
+                        else:
+                            logger.error(
+                                "Can't find unbuild with name: <%s>", unbuild_name
+                            )
 
 
     def get_element_and_children_data(self, element):


### PR DESCRIPTION
When unbuild is not found, there are two possibilities:
- No name found => it's a test analytic, so it should be marked as processed, like a right one.
- Incorrect unbuild name => it should be kept as unprocessed, so external users can check it and fix the problem.

cc @ChristianSantamaria 