### PR TITLE
[13.0][FIX] mrp_unbuild_cust_alu_analytics_valuation: process types moved from hour to unit based

### DIFF
--- a/mrp_unbuild_cust_alu_analytics_valuation/__manifest__.py
+++ b/mrp_unbuild_cust_alu_analytics_valuation/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.1.0",
+    "version": "13.0.1.1.1",
     "category": "Manufacturing",
     "website": "https://github.com/solvosci/slv-manufacture",
     "depends": ["mrp_unbuild_cust_alu_analytics", "stock_valuation_mrp"],

--- a/mrp_unbuild_cust_alu_analytics_valuation/models/mrp_unbuild_process_type.py
+++ b/mrp_unbuild_cust_alu_analytics_valuation/models/mrp_unbuild_process_type.py
@@ -145,8 +145,8 @@ class MrpUnbuildProcessType(models.Model):
         costs = {
             "cost_extra_pt_manpower": et * self._get_cost(production_id, "cost_hr_manpower"),
             "cost_extra_pt_energy": et * self._get_cost(production_id, "cost_hr_energy"),
-            "cost_extra_pt_amortization": et * self._get_cost(production_id, "cost_hr_amortization"),
-            "cost_extra_pt_repair_maintenance_mgmt": et * self._get_cost(production_id, "cost_hr_repair_maintenance_mgmt"),
+            "cost_extra_pt_amortization": qty * self._get_cost(production_id, "cost_hr_amortization"),
+            "cost_extra_pt_repair_maintenance_mgmt": qty * self._get_cost(production_id, "cost_hr_repair_maintenance_mgmt"),
             "cost_extra_pt_consumable": qty * self._get_cost(production_id, "cost_unit_consumable"),
             "cost_extra_pt_maquila": qty * self._get_cost(production_id, "cost_unit_maquila"),
         }

--- a/mrp_unbuild_cust_alu_analytics_valuation/views/mrp_unbuild_process_type_views.xml
+++ b/mrp_unbuild_cust_alu_analytics_valuation/views/mrp_unbuild_process_type_views.xml
@@ -22,19 +22,11 @@
                                 name="cost_hr_manpower"
                                 string="Manpower"
                             />
-                            <field
-                                name="cost_hr_energy"
-                                string="Energy"
-                            />
                         </group>
                         <group>
                             <field
-                                name="cost_hr_amortization"
-                                string="Amortization"
-                            />
-                            <field
-                                name="cost_hr_repair_maintenance_mgmt"
-                                string="Repair/Maintenance"
+                                name="cost_hr_energy"
+                                string="Energy"
                             />
                         </group>
                         <field name="currency_id" invisible="1"/>
@@ -48,6 +40,14 @@
                             />
                         </group>
                         <group>
+                            <field
+                                name="cost_hr_amortization"
+                                string="Amortization"
+                            />
+                            <field
+                                name="cost_hr_repair_maintenance_mgmt"
+                                string="Repair/Maintenance"
+                            />
                             <field
                                 name="cost_unit_consumable"
                                 string="Consumables"


### PR DESCRIPTION
With this fix, amortization and repair/maintenance unit costs are treated like consumables or maquilas (based on unit, e.g. "tons") rather than hours based.