### PR TITLE
[13.0][FIX] mrp_unbuild_cust_alu_analytics_valuation: sudo computation for unitary costs

### DIFF
--- a/mrp_unbuild_cust_alu_analytics_valuation/__manifest__.py
+++ b/mrp_unbuild_cust_alu_analytics_valuation/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.1.1",
+    "version": "13.0.1.1.2",
     "category": "Manufacturing",
     "website": "https://github.com/solvosci/slv-manufacture",
     "depends": ["mrp_unbuild_cust_alu_analytics", "stock_valuation_mrp"],

--- a/mrp_unbuild_cust_alu_analytics_valuation/models/mrp_unbuild.py
+++ b/mrp_unbuild_cust_alu_analytics_valuation/models/mrp_unbuild.py
@@ -252,6 +252,7 @@ class MrpUnbuild(models.Model):
         })
 
     def _compute_cost_unitary_fields(self):
+        self = self.sudo()
         mrp_unitary = self.filtered(
             lambda x: float_compare(
                 x.cost_product_qty,


### PR DESCRIPTION
With this fix accessing affected fields by `_compute_cost_unitary_fields()` method is granted, preventing future record rules for unbuilds that could crash with older implementation (a write access error could be raised even loading the form).