### PR TITLE
[15.0][FIX] mrp_stock_product_sn_reservation: allow (un)lock S/Ns for "To Close" state

### DIFF
--- a/mrp_stock_product_sn_reservation/__manifest__.py
+++ b/mrp_stock_product_sn_reservation/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "15.0.1.0.0",
+    "version": "15.0.1.0.1",
     "category": "Manufacturing/Manufacturing",
     "website": "https://github.com/solvosci/slv-manufacture",
     "depends": ["mrp", "stock_product_sn_reservation"],

--- a/mrp_stock_product_sn_reservation/models/mrp_production.py
+++ b/mrp_stock_product_sn_reservation/models/mrp_production.py
@@ -11,7 +11,7 @@ class MrpProduction(models.Model):
     def _compute_sn_locked_invisible(self):
         super()._compute_sn_locked_invisible()
         locked_inv_mrp_ids = self.filtered(
-            lambda x: x.state not in ["confirmed", "progress"]
+            lambda x: x.state not in ["confirmed", "progress", "to_close"]
         )
         locked_inv_mrp_ids.update({"sn_locked_invisible": True})
         (self - locked_inv_mrp_ids).update({"sn_locked_invisible": False})


### PR DESCRIPTION
In "To Close" state some operations, like editing lines quantities, are allowed. Then, it's coherent enabling S/N operations as well.

Before this fix, S/N flag was disabled at such state, so if MO was previously locked, it wasn't possible to revert it. This fixes it.