### PR TITLE
[13.0][FIX] mrp_unbuild_bom_cust_qty: missing `@api.depends` for some computed non stored fields

### DIFF
--- a/mrp_unbuild_bom_cust_qty/__manifest__.py
+++ b/mrp_unbuild_bom_cust_qty/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.3.0.0",
+    "version": "13.0.3.0.1",
     "category": "Manufacturing",
     "website": "https://github.com/solvosci/slv-manufacture",
     "depends": ["mrp"],

--- a/mrp_unbuild_bom_cust_qty/models/mrp_unbuild_bom_mixin.py
+++ b/mrp_unbuild_bom_cust_qty/models/mrp_unbuild_bom_mixin.py
@@ -1,7 +1,7 @@
 # © 2021 Solvos Consultoría Informática (<http://www.solvos.es>)
 # License LGPL-3.0 (http://www.gnu.org/licenses/lgpl-3.0.html)
 
-from odoo import fields, models
+from odoo import api, fields, models
 
 
 class MrpUnbuildBoMMixin(models.AbstractModel):
@@ -59,6 +59,7 @@ class MrpUnbuildBoMMixin(models.AbstractModel):
         uom_diff.write({"is_product_uom_diff": True})
         (self - uom_diff).write({"is_product_uom_diff": False})
 
+    @api.depends("bom_id", "bom_line_id.bom_id")
     def _compute_check_bom_line(self):
         for record in self:
             if record.bom_line_id.bom_id == record.bom_id:

--- a/mrp_unbuild_bom_cust_qty/models/mrp_unbuild_bom_total.py
+++ b/mrp_unbuild_bom_cust_qty/models/mrp_unbuild_bom_total.py
@@ -66,6 +66,7 @@ class MrpUnbuildBoMTotals(models.Model):
             for bom_quant in record.unbuild_id.bom_quants_ids.filtered(lambda x: x.bom_line_id.id == record.bom_line_id.id):
                 record.total_qty += bom_quant.custom_qty
 
+    @api.depends("bom_line_id", "unbuild_id.bom_quants_ids.bom_line_id")
     def _compute_bom_quant_ids(self):
         for record in self:
             record.bom_quant_ids = record.unbuild_id.bom_quants_ids.filtered(lambda x: x.bom_line_id.id == record.bom_line_id.id)


### PR DESCRIPTION
Some computed fields had no `@api.depends` clause. It was no problem for end user experience using Odoo frontend but, for python backend process such fields couldn't be updated and some information could be generated in an incomplete way e.g. creating an unbuild and, then, validating it.

This is required for https://github.com/solvosci/beyond-alea-interface-priv/pull/22