### PR TITLE
[13.0][IMP] mrp_unbuild_cust_alu_analytics_valuation: product cost hooks // picking valuation data performance improvement

### DIFF
--- a/mrp_unbuild_cust_alu_analytics_valuation/__manifest__.py
+++ b/mrp_unbuild_cust_alu_analytics_valuation/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.3.0",
+    "version": "13.0.1.4.0",
     "category": "Manufacturing",
     "website": "https://github.com/solvosci/slv-manufacture",
     "depends": ["mrp_unbuild_cust_alu_analytics", "stock_valuation_mrp"],

--- a/mrp_unbuild_cust_alu_analytics_valuation/__manifest__.py
+++ b/mrp_unbuild_cust_alu_analytics_valuation/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "13.0.1.2.0",
+    "version": "13.0.1.3.0",
     "category": "Manufacturing",
     "website": "https://github.com/solvosci/slv-manufacture",
     "depends": ["mrp_unbuild_cust_alu_analytics", "stock_valuation_mrp"],

--- a/mrp_unbuild_cust_alu_analytics_valuation/i18n/es.po
+++ b/mrp_unbuild_cust_alu_analytics_valuation/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-16 17:52+0000\n"
-"PO-Revision-Date: 2024-12-16 18:55+0100\n"
+"POT-Creation-Date: 2025-04-16 16:13+0000\n"
+"PO-Revision-Date: 2025-04-16 18:16+0200\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "Language: es\n"
@@ -167,7 +167,7 @@ msgid "Consumables unit cost (by unit)"
 msgstr "Cost. unitario de consumibles (por unidad)"
 
 #. module: mrp_unbuild_cust_alu_analytics_valuation
-#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.view_picking_form
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.stock_picking_valulation_data_form_view
 msgid "Cost"
 msgstr "Coste"
 
@@ -220,6 +220,11 @@ msgid "Disabled for manufacturing/unbuild valuation"
 msgstr "Deshabilitado para valoración en fabricación/despieces"
 
 #. module: mrp_unbuild_cust_alu_analytics_valuation
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.stock_picking_valulation_data_form_view
+msgid "Discard"
+msgstr "Descartar"
+
+#. module: mrp_unbuild_cust_alu_analytics_valuation
 #: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.mrp_bom_form_process_type_form_view_mrp_bom_cust_analytics_valuation
 msgid "Energy"
 msgstr "Energía"
@@ -254,12 +259,12 @@ msgid "Has cost management residue"
 msgstr "Tiene coste de gestión de residuo"
 
 #. module: mrp_unbuild_cust_alu_analytics_valuation
-#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.view_picking_form
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.stock_picking_valulation_data_form_view
 msgid "Income"
 msgstr "Ingreso"
 
 #. module: mrp_unbuild_cust_alu_analytics_valuation
-#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.view_picking_form
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.stock_picking_valulation_data_form_view
 msgid "Involved UBs"
 msgstr "Despieces involucrados"
 
@@ -294,7 +299,7 @@ msgid "Maquilas unit cost (by unit)"
 msgstr "Coste unitario de maquilas (por unidad)"
 
 #. module: mrp_unbuild_cust_alu_analytics_valuation
-#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.view_picking_form
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.stock_picking_valulation_data_form_view
 msgid "Margin"
 msgstr "Margen"
 
@@ -345,6 +350,11 @@ msgstr "Coste original del producto"
 #: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.mrp_unbuild_form_view_user
 msgid "Performance"
 msgstr "Rendimiento"
+
+#. module: mrp_unbuild_cust_alu_analytics_valuation
+#: model:ir.actions.act_window,name:mrp_unbuild_cust_alu_analytics_valuation.action_view_valuation_data
+msgid "Picking Valuation Data"
+msgstr "Datos de valoración del albarán"
 
 #. module: mrp_unbuild_cust_alu_analytics_valuation
 #: model:ir.model,name:mrp_unbuild_cust_alu_analytics_valuation.model_product_pricelist
@@ -428,7 +438,7 @@ msgstr "Albarán"
 #. module: mrp_unbuild_cust_alu_analytics_valuation
 #: model:ir.model,name:mrp_unbuild_cust_alu_analytics_valuation.model_mrp_unbuild
 msgid "Unbuild Order"
-msgstr "örden de desconstrucción"
+msgstr "Orden de desconstrucción"
 
 #. module: mrp_unbuild_cust_alu_analytics_valuation
 #: model:ir.model,name:mrp_unbuild_cust_alu_analytics_valuation.model_mrp_unbuild_process_type
@@ -595,7 +605,7 @@ msgid "Valuation Currency"
 msgstr "Moneda de la valoración"
 
 #. module: mrp_unbuild_cust_alu_analytics_valuation
-#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.view_picking_form
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.stock_valuation_layer_picking
 msgid "Valuation Data"
 msgstr "Datos de valoración"
 

--- a/mrp_unbuild_cust_alu_analytics_valuation/i18n/mrp_unbuild_cust_alu_analytics_valuation.pot
+++ b/mrp_unbuild_cust_alu_analytics_valuation/i18n/mrp_unbuild_cust_alu_analytics_valuation.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 13.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2024-12-16 17:52+0000\n"
-"PO-Revision-Date: 2024-12-16 17:52+0000\n"
+"POT-Creation-Date: 2025-04-16 16:13+0000\n"
+"PO-Revision-Date: 2025-04-16 16:13+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -149,7 +149,7 @@ msgid "Consumables unit cost (by unit)"
 msgstr ""
 
 #. module: mrp_unbuild_cust_alu_analytics_valuation
-#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.view_picking_form
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.stock_picking_valulation_data_form_view
 msgid "Cost"
 msgstr ""
 
@@ -202,6 +202,11 @@ msgid "Disabled for manufacturing/unbuild valuation"
 msgstr ""
 
 #. module: mrp_unbuild_cust_alu_analytics_valuation
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.stock_picking_valulation_data_form_view
+msgid "Discard"
+msgstr ""
+
+#. module: mrp_unbuild_cust_alu_analytics_valuation
 #: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.mrp_bom_form_process_type_form_view_mrp_bom_cust_analytics_valuation
 msgid "Energy"
 msgstr ""
@@ -236,12 +241,12 @@ msgid "Has cost management residue"
 msgstr ""
 
 #. module: mrp_unbuild_cust_alu_analytics_valuation
-#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.view_picking_form
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.stock_picking_valulation_data_form_view
 msgid "Income"
 msgstr ""
 
 #. module: mrp_unbuild_cust_alu_analytics_valuation
-#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.view_picking_form
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.stock_picking_valulation_data_form_view
 msgid "Involved UBs"
 msgstr ""
 
@@ -276,7 +281,7 @@ msgid "Maquilas unit cost (by unit)"
 msgstr ""
 
 #. module: mrp_unbuild_cust_alu_analytics_valuation
-#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.view_picking_form
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.stock_picking_valulation_data_form_view
 msgid "Margin"
 msgstr ""
 
@@ -322,6 +327,11 @@ msgstr ""
 #. module: mrp_unbuild_cust_alu_analytics_valuation
 #: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.mrp_unbuild_form_view_user
 msgid "Performance"
+msgstr ""
+
+#. module: mrp_unbuild_cust_alu_analytics_valuation
+#: model:ir.actions.act_window,name:mrp_unbuild_cust_alu_analytics_valuation.action_view_valuation_data
+msgid "Picking Valuation Data"
 msgstr ""
 
 #. module: mrp_unbuild_cust_alu_analytics_valuation
@@ -571,7 +581,7 @@ msgid "Valuation Currency"
 msgstr ""
 
 #. module: mrp_unbuild_cust_alu_analytics_valuation
-#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.view_picking_form
+#: model_terms:ir.ui.view,arch_db:mrp_unbuild_cust_alu_analytics_valuation.stock_valuation_layer_picking
 msgid "Valuation Data"
 msgstr ""
 

--- a/mrp_unbuild_cust_alu_analytics_valuation/models/product_history_average_price.py
+++ b/mrp_unbuild_cust_alu_analytics_valuation/models/product_history_average_price.py
@@ -35,9 +35,13 @@ class ProductHistoryAveragePrice(models.Model):
             ub_quantity = svl.stock_move_id._compute_unbuild_svl_quantity(svl.quantity)
             # TODO float_is_zero for ub_quantity
             return (
-                ub_quantity and unbuild_id.cost_unit_price
+                ub_quantity and self._get_svl_unbuild_cost(svl)
                 or 0.0,
                 svl.quantity
             )
         else:
             return super()._update_dependent_svls_get_svl_data(svl)
+        
+    def _get_svl_unbuild_cost(self, svl):
+        unbuild_id = svl.stock_move_id.unbuild_id
+        return unbuild_id and unbuild_id.cost_unit_price or 0.0

--- a/mrp_unbuild_cust_alu_analytics_valuation/models/stock_move.py
+++ b/mrp_unbuild_cust_alu_analytics_valuation/models/stock_move.py
@@ -21,9 +21,7 @@ class StockMove(models.Model):
         self.ensure_one()
         if self.product_id.has_waste_cost_mgmt:
             return 0.0
-        quant_total = self.unbuild_id.bom_quants_total_ids.filtered(
-            lambda x: x.bom_line_id.product_id == self.product_id
-        )
+        quant_total = self._get_quant_total_id()
         # TODO it should be only one, but...
         if quant_total and quant_total[0].disabled_mrp_unbuild_valuation:
             return 0.0
@@ -72,3 +70,9 @@ class StockMove(models.Model):
             return sale_line_id.price_unit
         else:
             return 0.0
+        
+    def _get_quant_total_id(self):
+        self.ensure_one()
+        return self.unbuild_id.bom_quants_total_ids.filtered(
+            lambda x: x.bom_line_id.product_id == self.product_id
+        )

--- a/mrp_unbuild_cust_alu_analytics_valuation/models/stock_picking.py
+++ b/mrp_unbuild_cust_alu_analytics_valuation/models/stock_picking.py
@@ -49,6 +49,14 @@ class StockPicking(models.Model):
         string="Valuation Involved Unbuilds",
     )
 
+    def action_view_valuation_data(self):
+        self.ensure_one()
+        action = self.env.ref(
+            "mrp_unbuild_cust_alu_analytics_valuation.action_view_valuation_data"
+        ).read()[0]
+        action["res_id"] = self.id
+        return action
+
     def _compute_val_cost(self):
         pick_out = self.filtered(
             lambda x: x.picking_type_code == "outgoing" and x.state == "done"

--- a/mrp_unbuild_cust_alu_analytics_valuation/views/stock_picking_views.xml
+++ b/mrp_unbuild_cust_alu_analytics_valuation/views/stock_picking_views.xml
@@ -1,23 +1,12 @@
 <?xml version="1.0" encoding="utf-8"?>
 <odoo>
-    <record id="view_picking_form" model="ir.ui.view">
-        <field name="name">stock.picking.form (in mrp_unbuild_cust_alu_analytics_valuation)</field>
+    <record id="stock_picking_valulation_data_form_view" model="ir.ui.view">        
+        <field name="name">stock.picking.valuation.data.form</field>
         <field name="model">stock.picking</field>
-        <field name="inherit_id" ref="stock.view_picking_form" />
+        <field name="priority" eval="999"/>
         <field name="arch" type="xml">
-            <xpath expr="//notebook" position="inside">
-                <page
-                    name="valuation_data"
-                    string="Valuation Data"
-                    groups="account.group_account_invoice"
-                    attrs="{
-                        'invisible': [
-                            '|',
-                                ('state', '!=', 'done'),
-                                ('picking_type_code', '!=', 'outgoing'),
-                        ],
-                    }"
-                >
+            <form>
+                <sheet>
                     <group>
                         <group>
                             <field name="val_currency_id" invisible="1" />
@@ -52,8 +41,39 @@
                             />
                         </group>
                     </group>
-                </page>
-            </xpath>
+                </sheet>
+                <footer>
+                    <button string="Discard" class="btn-secondary" special="cancel"/>
+                </footer>
+            </form>
         </field>
-    </record>    
+    </record>
+
+    <record id="action_view_valuation_data" model="ir.actions.act_window">
+        <field name="name">Picking Valuation Data</field>
+        <field name="type">ir.actions.act_window</field>
+        <field name="res_model">stock.picking</field>
+        <field name="view_mode">form</field>
+        <field name="view_id" ref="stock_picking_valulation_data_form_view" />
+        <field name="target">new</field>
+    </record>
+
+    <record id="stock_valuation_layer_picking" model="ir.ui.view">        
+        <field name="name">stock.valuation.layer.picking (in mrp_unbuild_cust_alu_analytics_valuation)</field>
+        <field name="model">stock.picking</field>
+        <field name="inherit_id" ref="stock_account.stock_valuation_layer_picking" />
+        <field name="arch" type="xml">
+            <button name="action_view_stock_valuation_layers" position="after">
+                <button
+                    string="Valuation Data"
+                    type="object"
+                    name="action_view_valuation_data"
+                    class="oe_stat_button"
+                    icon="fa-eur"
+                    groups="account.group_account_invoice"
+                    attrs="{'invisible': [('state', 'not in', ['done'])]}"
+                />
+            </button>
+        </field>
+    </record>
 </odoo>


### PR DESCRIPTION
Two improvements added:

* Product cost hooks: this is required for individual products cost that comes from Alea
* Picking valuation data performance improvement: picking form load was too load, is moved to a secondary action