### PR TITLE
[15.0][FIX] mrp_project_analytic: from_child mark smart button form doesn't work sometimes

### DIFF
--- a/mrp_project_analytic/__manifest__.py
+++ b/mrp_project_analytic/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "15.0.3.0.0",
+    "version": "15.0.3.0.1",
     "category": "Manufacturing",
     "website": "https://github.com/solvosci/slv-manufacture",
     "depends": ["mrp_project", "mrp_account"],

--- a/mrp_project_analytic/models/mrp_production.py
+++ b/mrp_project_analytic/models/mrp_production.py
@@ -67,7 +67,7 @@ class ManufactureOrder(models.Model):
         if not self.env.user.has_group("mrp.group_mrp_manager"):
             raise ValidationError(_("Only Production Managers can do this."))
         for mrp in self.browse(
-            self.env.context.get("active_ids", self.ids)
+            self.ids or self.env.context.get("active_ids")
         ).filtered(lambda x: x.state == "done"):
             # TODO mark_analytic_mrp_from_child is singleton at this point
             mrp.mark_analytic_mrp_from_child()


### PR DESCRIPTION
Before this, "Set 'From Child' for journal items" form button didn't work when form was loaded from another one (e.g. from project), because of list action management. This fixes it.