### PR TITLE
[17.0][FIX] mdc_weight_mgmt: Fix overlapping check

### DIFF
--- a/mdc_weight_mgmt/__manifest__.py
+++ b/mdc_weight_mgmt/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "17.0.1.0.0",
+    "version": "17.0.1.0.1",
     "category": "Manufacture",
     "website": "https://github.com/solvosci/manufacture",
     "depends": ["product","maintenance"],

--- a/mdc_weight_mgmt/models/mdc_weight_record.py
+++ b/mdc_weight_mgmt/models/mdc_weight_record.py
@@ -157,8 +157,8 @@ class MdcWeightRecord(models.Model):
         overlapping = self.search([
             ('equipment_id', '=', equipment_id.id),
             '|',
-                '&', ('start', '<=', start), ('end', '>=', start),
-                '&', ('start', '<=', end),   ('end', '>=', end),
+                '&', ('start', '<=', start), ('end', '>', start),
+                '&', ('start', '<', end),   ('end', '>=', end),
         ], limit=1)
         if overlapping:
             return (_(


### PR DESCRIPTION
Fix the overlapping check in the `mdc_weight_mgmt` module to ensure that correctly identifies overlapping records by adjusting the search and ensuring that the current record is excluded from the check.