### PR TITLE
[17.0][IMP] mdc_weight_mgmt_xml_import: Automatic deletion of processed files

### DIFF
--- a/mdc_weight_mgmt_xml_import/__manifest__.py
+++ b/mdc_weight_mgmt_xml_import/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "AGPL-3",
-    "version": "17.0.1.2.1",
+    "version": "17.0.1.3.0",
     "category": "Manufacture",
     "website": "https://github.com/solvosci/manufacture",
     "depends": [

--- a/mdc_weight_mgmt_xml_import/data/ir_cron_mdc_weight_import.xml
+++ b/mdc_weight_mgmt_xml_import/data/ir_cron_mdc_weight_import.xml
@@ -9,4 +9,16 @@
         <field name="state">code</field>
         <field name="code">model._cron_import_xml_weight()</field>
     </record>
+
+    <record id="ir_cron_mdc_cleanup_processed_files" model="ir.cron">
+        <field name="name">Automated clean processed XML Weight Files</field>
+        <field name="user_id" ref="base.user_root" />
+        <field name="active" eval="False" />
+        <field name="interval_number">1</field>
+        <field name="interval_type">days</field>
+        <field name="numbercall">-1</field>
+        <field name="model_id" ref="model_maintenance_equipment" />
+        <field name="state">code</field>
+        <field name="code">model._cron_mdc_xml_cleanup_processed_files()</field>
+    </record>
 </odoo>

--- a/mdc_weight_mgmt_xml_import/i18n/es.po
+++ b/mdc_weight_mgmt_xml_import/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-04 07:41+0000\n"
-"PO-Revision-Date: 2025-09-04 07:41+0000\n"
+"POT-Creation-Date: 2025-09-22 11:08+0000\n"
+"PO-Revision-Date: 2025-09-22 11:08+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -104,6 +104,11 @@ msgid "Attachment Count"
 msgstr "Número de adjuntos"
 
 #. module: mdc_weight_mgmt_xml_import
+#: model:ir.actions.server,name:mdc_weight_mgmt_xml_import.ir_cron_mdc_cleanup_processed_files_ir_actions_server
+msgid "Automated clean processed XML Weight Files"
+msgstr "Borrado automático de archivos de pesadas XML procesados"
+
+#. module: mdc_weight_mgmt_xml_import
 #: model:ir.actions.server,name:mdc_weight_mgmt_xml_import.ir_cron_mdc_weight_import_ir_actions_server
 msgid "Automated import XML daily"
 msgstr "Importación automática XML diaria"
@@ -157,6 +162,20 @@ msgstr "Creado por"
 #: model:ir.model.fields,field_description:mdc_weight_mgmt_xml_import.field_mdc_weight_record_error__create_date
 msgid "Created on"
 msgstr "Fecha de creación"
+
+#. module: mdc_weight_mgmt_xml_import
+#: model:ir.model.fields,field_description:mdc_weight_mgmt_xml_import.field_maintenance_equipment__mdc_xml_days_delete
+msgid "Days to Keep Processed Files"
+msgstr "Días para conservar los archivos procesados"
+
+#. module: mdc_weight_mgmt_xml_import
+#: model:ir.model.fields,help:mdc_weight_mgmt_xml_import.field_maintenance_equipment__mdc_xml_days_delete
+msgid ""
+"Delete files older than this number of days from the processed folder.\n"
+"        If set to less than 1, files will be kept indefinitely."
+msgstr ""
+"Eliminar archivos más antiguos que este número de días de la carpeta de procesados. \n"
+"        Si se establece en menos de 1, los archivos se conservarán indefinidamente."
 
 #. module: mdc_weight_mgmt_xml_import
 #: model:ir.model.fields,field_description:mdc_weight_mgmt_xml_import.field_mdc_weight_record_error__display_name

--- a/mdc_weight_mgmt_xml_import/i18n/mdc_weight_mgmt_xml_import.pot
+++ b/mdc_weight_mgmt_xml_import/i18n/mdc_weight_mgmt_xml_import.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-09-04 07:41+0000\n"
-"PO-Revision-Date: 2025-09-04 07:41+0000\n"
+"POT-Creation-Date: 2025-09-22 11:06+0000\n"
+"PO-Revision-Date: 2025-09-22 11:06+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -67,6 +67,11 @@ msgid "Attachment Count"
 msgstr ""
 
 #. module: mdc_weight_mgmt_xml_import
+#: model:ir.actions.server,name:mdc_weight_mgmt_xml_import.ir_cron_mdc_cleanup_processed_files_ir_actions_server
+msgid "Automated clean processed XML Weight Files daily"
+msgstr ""
+
+#. module: mdc_weight_mgmt_xml_import
 #: model:ir.actions.server,name:mdc_weight_mgmt_xml_import.ir_cron_mdc_weight_import_ir_actions_server
 msgid "Automated import XML daily"
 msgstr ""
@@ -119,6 +124,18 @@ msgstr ""
 #. module: mdc_weight_mgmt_xml_import
 #: model:ir.model.fields,field_description:mdc_weight_mgmt_xml_import.field_mdc_weight_record_error__create_date
 msgid "Created on"
+msgstr ""
+
+#. module: mdc_weight_mgmt_xml_import
+#: model:ir.model.fields,field_description:mdc_weight_mgmt_xml_import.field_maintenance_equipment__mdc_xml_days_delete
+msgid "Days to Keep Processed Files"
+msgstr ""
+
+#. module: mdc_weight_mgmt_xml_import
+#: model:ir.model.fields,help:mdc_weight_mgmt_xml_import.field_maintenance_equipment__mdc_xml_days_delete
+msgid ""
+"Delete files older than this number of days from the processed folder.\n"
+"        If set to less than 1, files will be kept indefinitely."
 msgstr ""
 
 #. module: mdc_weight_mgmt_xml_import

--- a/mdc_weight_mgmt_xml_import/models/maintenance_equipment.py
+++ b/mdc_weight_mgmt_xml_import/models/maintenance_equipment.py
@@ -27,6 +27,18 @@ class MaintenanceEquipment(models.Model):
         string="XML Processed Folder Path",
         help="Path to the folder where processed XML files are moved."
     )
+    mdc_timezone = fields.Selection(
+        selection=_tz_get,
+        string="Timezone",
+        default=lambda self: self.env.user.tz or 'UTC',
+        help="Timezone for the equipment."
+    )
+    mdc_xml_days_delete = fields.Integer(
+        string="Days to Keep Processed Files",
+        default=90,
+        help="""Delete files older than this number of days from the processed folder.
+        If set to less than 1, files will be kept indefinitely.""",
+    )
     # FTP connection settings
     requires_ftp = fields.Boolean(
         string="Requires FTP Connection",
@@ -37,13 +49,6 @@ class MaintenanceEquipment(models.Model):
     ftp_user = fields.Char(string="Username")
     ftp_password = fields.Char(string="Password")
     ftp_folder = fields.Char(string="Folder")
-
-    mdc_timezone = fields.Selection(
-        selection=_tz_get,
-        string="Timezone",
-        default=lambda self: self.env.user.tz or 'UTC',
-        help="Timezone for the equipment."
-    )
 
     @api.model
     def _cron_import_xml_weight(self):
@@ -118,6 +123,37 @@ class MaintenanceEquipment(models.Model):
             error_model = self.env['mdc.weight.record.error'].sudo()
             created_errors = error_model.create(errors)
             created_errors.action_send_mail()
+
+    @api.model
+    def _cron_mdc_xml_cleanup_processed_files(self):
+        logger = logging.getLogger(__name__)
+        now = datetime.now()
+        for record in self.env['maintenance.equipment'].search([
+            ('mdc_xml_import_active', '=', True),
+            ('mdc_xml_days_delete', '>', 0),
+        ]):
+            processed_path = Path(record.mdc_xml_weight_processed_path or "")
+            if not processed_path.exists():
+                continue
+
+            deleted_files = []
+            for file in processed_path.iterdir():
+                if file.is_file():
+                    age_days = (now - datetime.fromtimestamp(file.stat().st_mtime)).days
+                    if age_days > record.mdc_xml_days_delete:
+                        try:
+                            file.unlink()
+                            deleted_files.append(file.name)
+                        except Exception as e:
+                            logger.error("Error deleting file %s: %s", file.name, e)
+
+            if deleted_files:
+                logger.warning(
+                    "Deleted processed XML files for equipment %s older than %s days: %s",
+                    record.name,
+                    record.mdc_xml_days_delete,
+                    ", ".join(deleted_files)
+                )
 # ********** Getters for XML data extraction ***********
     def get_statvalue_by_id(self,stat_id, unit=None, root=None, nsmap=None):
         query = f'.//wpt:Statvalue[@id="{stat_id}"]'

--- a/mdc_weight_mgmt_xml_import/readme/DESCRIPTION.md
+++ b/mdc_weight_mgmt_xml_import/readme/DESCRIPTION.md
@@ -1,3 +1,5 @@
-Automatically imports XML files from the configured folder with cron.
-Errors encountered during processing are stored in the system for later review and management.
-Also you can put a partner to notify those errors.
+Automatically imports XML files from the configured folder through a scheduled cron job.
+Any errors encountered during processing are logged in the system for later review and management,
+and a partner can be assigned to receive error notifications.
+In addition, the system supports automatic cleanup of processed files based on a configurable retention period (default: 90 days). 
+If the retention is set to 0, files will be kept indefinitely.

--- a/mdc_weight_mgmt_xml_import/readme/USAGE.md
+++ b/mdc_weight_mgmt_xml_import/readme/USAGE.md
@@ -23,3 +23,7 @@ The optional Folder field specifies the remote directory where the XML files are
 
 7. You can optionally configure a notification partner in *Weight Management* > *Configuration* > *Settings*.
 That partner will receive email alerts for any import errors detected during cron execution.
+
+8. You can define the retention period (in days) for processed files at the equipment level.
+By default, files are kept for 90 days. The cleanup runs daily via a scheduled cron job.
+If the value is set to 0, files will be kept indefinitely.

--- a/mdc_weight_mgmt_xml_import/views/maintenance_equipment_views.xml
+++ b/mdc_weight_mgmt_xml_import/views/maintenance_equipment_views.xml
@@ -26,6 +26,7 @@
                                 name="mdc_xml_weight_processed_path"
                                 required="mdc_xml_import_active == True"
                             />
+                            <field name="mdc_xml_days_delete"/>
                         </group>
                         <group
                             name="mdc_ftp_settings"


### PR DESCRIPTION
With this imp, you can set up an automatic deletion of processed XML files after a certain number of days. This is configured in the Maintenance Equipment form view, where a new field "Days to Delete Processed Files" has been added. If this field is set to a value greater than zero, a scheduled action will run daily to delete files in the processed path that are older than the specified number of days.