### PR TITLE
[17.0][FIX] mdc_weight_mgmt: Fix division by zero in calculations

### DIFF
--- a/mdc_weight_mgmt/__manifest__.py
+++ b/mdc_weight_mgmt/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "17.0.2.0.0",
+    "version": "17.0.2.0.1",
     "category": "Manufacture",
     "website": "https://github.com/solvosci/manufacture",
     "depends": ["product","maintenance"],

--- a/mdc_weight_mgmt/reports/mdc_weight_template.xml
+++ b/mdc_weight_mgmt/reports/mdc_weight_template.xml
@@ -153,9 +153,7 @@
                                                 <span t-field="record.weight_nom_qty" />
                                             </td>
                                             <td>
-                                                <t t-if="record.weight_dec_qty">
-                                                    <span t-field="record.weight_dec_qty" />
-                                                </t>
+                                                <span t-field="record.weight_dec_qty" />
                                             </td>
                                             <td style="text-align: left; padding: 3px;">
                                                 <span
@@ -191,10 +189,8 @@
                                                 <span t-field="record.weight_ok_tot_qty" />
                                             </td>
                                             <td>
-                                                <t t-if="record.weight_ok_dec_qty">
-                                                    <span t-field="record.weight_ok_dec_qty"
-                                                        t-options="{'widget': 'float', 'precision': 1}" />
-                                                </t>
+                                                <span t-field="record.weight_ok_dec_qty"
+                                                    t-options="{'widget': 'float', 'precision': 1}" />
                                             </td>
                                             <td>
                                                 <span t-field="record.weight_ok_avg_qty"
@@ -205,14 +201,10 @@
                                                     t-options="{'widget': 'float', 'precision': 2}" />
                                             </td>
                                             <td>
-                                                <t t-if="record.unit_reject_exceed">
-                                                    <span t-field="record.unit_reject_exceed" />
-                                                </t>
+                                                <span t-field="record.unit_reject_exceed" />
                                             </td>
                                             <td>
-                                                <t t-if="record.unit_reject_low">
-                                                    <span t-field="record.unit_reject_low" />
-                                                </t>
+                                                <span t-field="record.unit_reject_low" />
                                             </td>
                                             <td>
                                                 <span t-field="record.unit_reject_total" />

--- a/mdc_weight_mgmt/wizard/mdc_weight_record_report_wizard.py
+++ b/mdc_weight_mgmt/wizard/mdc_weight_record_report_wizard.py
@@ -1,6 +1,7 @@
 # © 2025 Solvos Consultoría Informática (<http://www.solvos.es>)
 # License LGPL-3 - See http://www.gnu.org/licenses/lgpl-3.0.html
 from odoo import models, fields, api, _
+from odoo.tools import float_is_zero
 from odoo.exceptions import UserError, ValidationError
 import pytz
 
@@ -127,13 +128,20 @@ class MdcWeightRecordReportWizard(models.TransientModel):
         return sum(getattr(record, key)for record in records)
 
     def total_avg(self, unit_a, unit_b):
+        if float_is_zero(unit_b, precision_digits=2):
+            return 0.0
         return unit_a/unit_b
 
     def total_pct_avg(self, unit_a, unit_b):
+        if float_is_zero(unit_b, precision_digits=2):
+            return 0.0
         return (unit_a/unit_b) * 100
 
     def total_weight_nom(self, records):
+        total_unit_ok = self.sum_total(records, 'unit_ok')
+        if float_is_zero(total_unit_ok, precision_digits=2):
+            return 0.0
         sum_weight_nom = 0
         for record in records:
             sum_weight_nom += record.weight_nom_qty * record.unit_ok
-        return (sum_weight_nom/self.sum_total(records,'unit_ok'))
+        return sum_weight_nom / total_unit_ok


### PR DESCRIPTION
When calculating average, percentage average and total nominal weight in the `weight_record_report_wizard`, ensure that division by zero is handled gracefully by returning 0.0 when the denominator is zero. This prevents runtime errors and ensures the stability of the module during report generation.

SLV-Ticket: HT01062
