### PR TITLE
[17.0][FIX] mdc_weight_mgmt[_xlsx_report]: Correct total nominal average calculation

### DIFF
--- a/mdc_weight_mgmt/__manifest__.py
+++ b/mdc_weight_mgmt/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "17.0.2.0.1",
+    "version": "17.0.2.0.2",
     "category": "Manufacture",
     "website": "https://github.com/solvosci/manufacture",
     "depends": ["product","maintenance"],

--- a/mdc_weight_mgmt/reports/mdc_weight_template.xml
+++ b/mdc_weight_mgmt/reports/mdc_weight_template.xml
@@ -215,6 +215,8 @@
                                             </td>
                                         </tr>
                                     </t>
+                                    <t t-set="total_total_weight_nom_qty"
+                                        t-value="o.total_weight_nom(mdc_weight_record_ids)" />
                                     <t t-set="total_period_min"
                                         t-value="o.sum_total(mdc_weight_record_ids, 'period_min')" />
                                     <t t-set="total_unit_totals"
@@ -238,7 +240,7 @@
                                     <t t-set="total_weight_ok_avg_qty"
                                         t-value="o.total_avg(total_weight_ok_tot_qty, total_unit_ok)*1000" />
                                     <t t-set="total_exceed_pct_avg"
-                                        t-value="o.total_pct_avg((total_weight_ok_avg_qty - record.weight_nom_qty),record.weight_nom_qty)" />
+                                        t-value="o.total_pct_avg((total_weight_ok_avg_qty - total_total_weight_nom_qty),total_total_weight_nom_qty)" />
                                     <t t-if="total_unit_reject_total">
                                         <t t-set="total_unit_reject_pct_avg"
                                             t-value="o.total_pct_avg(total_unit_reject_total, total_unit_totals)" />
@@ -254,8 +256,13 @@
                                         <t t-else="">
                                             <td></td>
                                         </t>
-                                        <td></td>
-                                        <td></td>
+                                        <td>
+                                            <span t-esc="total_total_weight_nom_qty"
+                                                t-options="{'widget': 'float', 'precision': 1}" />
+                                        </td>
+                                        <td>
+                                            <span t-field="record.weight_dec_qty" />
+                                        </td>
                                         <td></td>
                                         <td></td>
                                         <td>

--- a/mdc_weight_mgmt_xlsx_report/__manifest__.py
+++ b/mdc_weight_mgmt_xlsx_report/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "AGPL-3",
-    "version": "17.0.1.1.1",
+    "version": "17.0.1.1.2",
     "category": "Manufacture",
     "website": "https://github.com/solvosci/manufacture",
     "depends": [

--- a/mdc_weight_mgmt_xlsx_report/reports/report_xlsx.py
+++ b/mdc_weight_mgmt_xlsx_report/reports/report_xlsx.py
@@ -138,6 +138,7 @@ class MdcWeightXlsxReport(models.AbstractModel):
                     worksheet.write(row, 17, product_filtered.unit_reject_pct, decimal_format)
                     row += 1
 
+                total_total_weight_nom_qty = weight_records.total_weight_nom(products_filtered)
                 total_period_min = weight_records.sum_total(products_filtered, 'period_min')
                 total_unit_totals = weight_records.sum_total(products_filtered, 'unit_total')
                 total_unit_ok = weight_records.sum_total(products_filtered, 'unit_ok')
@@ -149,11 +150,13 @@ class MdcWeightXlsxReport(models.AbstractModel):
                 total_unit_x_min_avg = weight_records.total_avg(total_unit_ok, total_period_min)
                 total_weight_ok_avg_qty = weight_records.total_avg(total_weight_ok_tot_qty, total_unit_ok)*1000
                 total_unit_ok_pct_avg = weight_records.total_pct_avg(total_unit_ok, total_unit_totals)
-                total_exceed_pct_avg = weight_records.total_pct_avg((total_weight_ok_avg_qty - product_filtered.weight_nom_qty),product_filtered.weight_nom_qty)
+                total_exceed_pct_avg = weight_records.total_pct_avg((total_weight_ok_avg_qty - total_total_weight_nom_qty),total_total_weight_nom_qty)
                 if total_unit_reject_total:
                     total_unit_reject_pct_avg = weight_records.total_pct_avg(total_unit_reject_total, total_unit_totals)
 
                 worksheet.write(row, 0, product.name, header_format)
+                worksheet.write(row, 1, total_total_weight_nom_qty, integer_format)
+                worksheet.write(row, 2, product_filtered.weight_dec_qty or '', integer_format)
                 worksheet.write(row, 5, total_period_min, integer_format)
                 worksheet.write(row, 6, total_unit_totals, integer_format)
                 worksheet.write(row, 7, total_unit_x_min_avg, decimal_format)


### PR DESCRIPTION
Previously, calculations followed the provided example without including the nominal value in the product total, as it was not expected to change. This has now been updated to calculate and internally use the nominal value to ensure the average is computed correctly according to the original logic.

Manifest remains untouched until #143 is merged, so it can be tested in the MSC_Test environment.

SLV-TICKET: HT01063