### PR TITLE
[17.0][FIX] mdc_weight_mgmt: Fix unit_x_min calculation in report wizard

### DIFF
--- a/mdc_weight_mgmt/__manifest__.py
+++ b/mdc_weight_mgmt/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "17.0.3.0.0",
+    "version": "17.0.3.0.1",
     "category": "Manufacture",
     "website": "https://github.com/solvosci/manufacture",
     "depends": ["product","maintenance"],

--- a/mdc_weight_mgmt/reports/mdc_weight_template.xml
+++ b/mdc_weight_mgmt/reports/mdc_weight_template.xml
@@ -176,7 +176,7 @@
                                             </td>
                                             <td>
                                                 <span t-field="record.unit_x_min"
-                                                    t-options="{'widget': 'float', 'precision': 0}" />
+                                                    t-options="{'widget': 'float', 'precision': 2}" />
                                             </td>
                                             <td>
                                                 <span t-field="record.unit_ok" />
@@ -274,7 +274,7 @@
                                         </td>
                                         <td>
                                             <span t-esc="total_unit_x_min_avg"
-                                                t-options="{'widget': 'float', 'precision': 0}" />
+                                                t-options="{'widget': 'float', 'precision': 2}" />
                                         </td>
                                         <td>
                                             <span t-esc="total_unit_ok" />
@@ -368,7 +368,7 @@
                                     </td>
                                     <td>
                                         <span t-esc="equipment_total_unit_x_min_avg"
-                                            t-options="{'widget': 'float', 'precision': 0}" />
+                                            t-options="{'widget': 'float', 'precision': 2}" />
                                     </td>
                                     <td>
                                         <span t-esc="equipment_total_unit_ok" />

--- a/mdc_weight_mgmt/wizard/mdc_weight_record_report_wizard.py
+++ b/mdc_weight_mgmt/wizard/mdc_weight_record_report_wizard.py
@@ -134,7 +134,7 @@ class MdcWeightRecordReportWizard(models.TransientModel):
                         'unit_reject_low': self.sum_total(recs, 'unit_reject_low'),
                         'unit_reject_total': self.sum_total(recs, 'unit_reject_total'),
                     }
-                    unit_x_min = self.total_avg(sums['unit_ok'], sums['period_min'])
+                    unit_x_min = self.total_avg(sums['unit_total'], sums['period_min'])
                     unit_ok_pct = self.total_pct_avg(sums['unit_ok'], sums['unit_total'])
                     weight_ok_avg_qty = self.total_avg(sums['weight_ok_tot_qty'], sums['unit_ok']) * 1000
                     exceed_pct = self.total_pct_avg(weight_ok_avg_qty - weight_nom_qty, weight_nom_qty)


### PR DESCRIPTION
PR https://github.com/solvosci/slv-manufacture/pull/146 added report grouping by hour. When creating record on the fly, the calculation of unit_x_min was using unit_ok instead of unit_total, which could lead to incorrect results when there are rejected units. This commit corrects the calculation to use unit_total, ensuring that the average is calculated based on the total number of units.