### PR TITLE
[17.0][IMP] mdc_weight_mgmt: Add daily report for weight records

### DIFF
--- a/mdc_weight_mgmt/__manifest__.py
+++ b/mdc_weight_mgmt/__manifest__.py
@@ -8,7 +8,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "17.0.3.0.1",
+    "version": "17.0.3.1.0",
     "category": "Manufacture",
     "website": "https://github.com/solvosci/manufacture",
     "depends": ["product","maintenance"],

--- a/mdc_weight_mgmt/i18n/es.po
+++ b/mdc_weight_mgmt/i18n/es.po
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-12-12 09:04+0000\n"
-"PO-Revision-Date: 2025-12-12 09:04+0000\n"
+"POT-Creation-Date: 2026-02-27 12:35+0000\n"
+"PO-Revision-Date: 2026-02-27 12:35+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -141,6 +141,11 @@ msgstr "Creado por"
 #: model:ir.model.fields,field_description:mdc_weight_mgmt.field_mdc_weight_shift__create_date
 msgid "Created on"
 msgstr "Creado el"
+
+#. module: mdc_weight_mgmt
+#: model:ir.ui.menu,name:mdc_weight_mgmt.menu_mdc_weight_report_daily
+msgid "Daily Report"
+msgstr "Informe Diario"
 
 #. module: mdc_weight_mgmt
 #: model_terms:ir.ui.view,arch_db:mdc_weight_mgmt.view_weight_record_form
@@ -673,6 +678,11 @@ msgstr "Gestión de Pesadas"
 #: model:ir.actions.act_window,name:mdc_weight_mgmt.action_mdc_weight_products
 msgid "Weight Products"
 msgstr "Productos de pesadas"
+
+#. module: mdc_weight_mgmt
+#: model:ir.actions.server,name:mdc_weight_mgmt.action_weight_report_daily
+msgid "Weight Record Daily"
+msgstr "Informe Diario de Pesadas"
 
 #. module: mdc_weight_mgmt
 #: model:ir.ui.menu,name:mdc_weight_mgmt.menu_mdc_weight_report_wizard

--- a/mdc_weight_mgmt/i18n/mdc_weight_mgmt.pot
+++ b/mdc_weight_mgmt/i18n/mdc_weight_mgmt.pot
@@ -6,8 +6,8 @@ msgid ""
 msgstr ""
 "Project-Id-Version: Odoo Server 17.0\n"
 "Report-Msgid-Bugs-To: \n"
-"POT-Creation-Date: 2025-12-12 09:03+0000\n"
-"PO-Revision-Date: 2025-12-12 09:03+0000\n"
+"POT-Creation-Date: 2026-02-27 12:34+0000\n"
+"PO-Revision-Date: 2026-02-27 12:34+0000\n"
 "Last-Translator: \n"
 "Language-Team: \n"
 "MIME-Version: 1.0\n"
@@ -132,6 +132,11 @@ msgstr ""
 #: model:ir.model.fields,field_description:mdc_weight_mgmt.field_mdc_weight_record_report_wizard__create_date
 #: model:ir.model.fields,field_description:mdc_weight_mgmt.field_mdc_weight_shift__create_date
 msgid "Created on"
+msgstr ""
+
+#. module: mdc_weight_mgmt
+#: model:ir.ui.menu,name:mdc_weight_mgmt.menu_mdc_weight_report_daily
+msgid "Daily Report"
 msgstr ""
 
 #. module: mdc_weight_mgmt
@@ -662,6 +667,11 @@ msgstr ""
 #. module: mdc_weight_mgmt
 #: model:ir.actions.act_window,name:mdc_weight_mgmt.action_mdc_weight_products
 msgid "Weight Products"
+msgstr ""
+
+#. module: mdc_weight_mgmt
+#: model:ir.actions.server,name:mdc_weight_mgmt.action_weight_report_daily
+msgid "Weight Record Daily"
 msgstr ""
 
 #. module: mdc_weight_mgmt

--- a/mdc_weight_mgmt/views/mdc_weight_mgmt_menu.xml
+++ b/mdc_weight_mgmt/views/mdc_weight_mgmt_menu.xml
@@ -47,6 +47,15 @@
         <field name="type">ir.actions.act_window</field>
     </record>
 
+    <record id="action_weight_report_daily" model="ir.actions.server">
+        <field name="name">Weight Record Daily</field>
+        <field name="model_id" ref="model_mdc_weight_record_report_wizard"/>
+        <field name="state">code</field>
+        <field name="code">
+            action = env['mdc.weight.record.report.wizard'].action_open_today_weight_report()
+        </field>
+    </record>
+
     <menuitem
         id="menu_mdc_weight"
         name="Weight Management"
@@ -97,6 +106,14 @@
         parent="menu_mdc_weight_reports"
         sequence="30"
         action="action_weight_report_wizard"
+    />
+
+    <menuitem
+        id="menu_mdc_weight_report_daily"
+        name="Daily Report"
+        parent="menu_mdc_weight"
+        sequence="27"
+        action="action_weight_report_daily"
     />
 
     <menuitem

--- a/mdc_weight_mgmt/wizard/mdc_weight_record_report_wizard.py
+++ b/mdc_weight_mgmt/wizard/mdc_weight_record_report_wizard.py
@@ -175,6 +175,14 @@ class MdcWeightRecordReportWizard(models.TransientModel):
         self._validate_report_data()
         return self.env.ref('mdc_weight_mgmt.action_mdc_weight_report_pdf').report_action(self)
 
+    def action_open_today_weight_report(self):
+        today = fields.Date.context_today(self)
+        wizard = self.env['mdc.weight.record.report.wizard'].create({
+            'date_from': today,
+            'date_to': today,
+        })
+        return wizard.action_mdc_weight_report_html()
+
     def sum_total(self, records, key):
         return sum(getattr(record, key)for record in records)
 


### PR DESCRIPTION
With this IMP, we add a direct access to a daily report for weight records, which can be accessed from the menu that opens the report directly with the current day as filter.

SLV-Ticket: HT01154
@dalonsod 