### PR TITLE
[15.0][FIX] mrp_project: assign parent MO project to child MO

### DIFF
--- a/mrp_project/__manifest__.py
+++ b/mrp_project/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "LGPL-3",
-    "version": "15.0.2.0.0",
+    "version": "15.0.2.0.1",
     "category": "Manufacturing",
     "website": "https://github.com/solvosci/slv-manufacture",
     "depends": ["mrp", "project"],

--- a/mrp_project/models/mrp_production.py
+++ b/mrp_project/models/mrp_production.py
@@ -26,3 +26,12 @@ class ManufactureOrder(models.Model):
     @api.onchange("project_id")
     def _onchange_project_id_parent(self):
         self._assign_project_to_children()
+
+    @api.model
+    def create(self, values):
+        # This part of the code is triggered by another automated process and is executed by OdooBot with permissions
+        production = super().create(values)
+        production_source = production._get_sources()
+        if production_source and len(production_source) == 1:
+            production.project_id = production_source.project_id
+        return production


### PR DESCRIPTION
When a project is modified in a MO that has child MOs, the changes are automatically applied to those child MOs as well.

This only happens if the child MOs already exist;
if they are generated later, the changes are not applied. This fix resolves that issue.
@dalonsod 