### PR TITLE
[13.0][FIX] mrp_unbuild_cust_alu_analytics: proper BoM domain and default selection with process type restriction addition

### DIFF
--- a/mrp_unbuild_cust_alu_analytics/__manifest__.py
+++ b/mrp_unbuild_cust_alu_analytics/__manifest__.py
@@ -7,7 +7,7 @@
     """,
     "author": "Solvos",
     "license": "AGPL-3",
-    "version": "13.0.1.10.0",
+    "version": "13.0.1.10.1",
     "category": "Manufacturing",
     "website": "https://github.com/solvosci/slv-manufacture",
     "depends": ["mrp_unbuild_advanced", "mrp_unbuild_bom_cust_qty", "report_xlsx", "mrp_unbuild_qc", "mrp_unbuild_bom_cust_qty", "mrp_unbuild_done_message"],

--- a/mrp_unbuild_cust_alu_analytics/models/mrp_unbuild.py
+++ b/mrp_unbuild_cust_alu_analytics/models/mrp_unbuild.py
@@ -26,8 +26,26 @@ class MrpUnbuild(models.Model):
 
     @api.onchange('product_id')
     def _onchange_product_id(self):
+        # TODO this code is completely bypassing base _onchange_product_id (https://github.com/odoo/odoo/blob/3a28e5b0adbb36bdb1155a6854cdfbe4e7f9b187/addons/mrp/models/mrp_production.py#L588)
+        # and this can cause problems!
         if self.product_id and self.process_type_id:
-            self.bom_id = self.product_id.product_tmpl_id.bom_ids.filtered(lambda r: r.process_type_id == self.process_type_id)[0]
+            # For selected process type, custom variant BoM is preferred;
+            # if not found, a "generic" one (for every variant) is accepted
+            product_bom_ids = self.product_id.product_tmpl_id.bom_ids.filtered(
+                lambda r: (
+                    r.process_type_id == self.process_type_id
+                    and (
+                        not r.product_id
+                        or r.product_id == self.product_id
+                    )
+                )
+            )
+            self.bom_id = (
+                product_bom_ids.filtered(
+                    lambda x: x.product_id and x.product_id == self.product_id
+                )[:1]
+                or product_bom_ids[:1]
+            )
         else:
             super(MrpUnbuild, self)._onchange_product_id()
 
@@ -48,10 +66,17 @@ class MrpUnbuild(models.Model):
     @api.onchange("product_id", "process_type_id")
     def _onchange_product_id_process_type_id(self):
         for record in self:
+            # Condition inspired in https://github.com/odoo/odoo/blob/4cc086d330b73514fbc64a7fcf22d8a7a9f1b691/addons/mrp/models/mrp_production.py#L120-L130
+            # To original bom domain process type AND condition is actually added
             domain_bom_id = [
-                "&",
+                ("type", "=", "normal"),
+                ("company_id", "in", [record.company_id.id, False]),
                 ("process_type_id", "=", record.process_type_id.id),
-                ("product_tmpl_id", "=", record.product_id.product_tmpl_id.id)
+                "|",            
+                    ("product_id", "=", record.product_id.id),
+                    "&",
+                        ("product_tmpl_id", "=", record.product_id.product_tmpl_id.id),
+                        ("product_id", "=", False),
             ]
             domain_product_id = [
                 ("process_type_ids", "=", record.process_type_id.id),


### PR DESCRIPTION
Before this fix an incomplete domain was set for unbuild bill of materials when process type was set:
* Comparing to standard default, company and Bom type conditions were removed
* Variant condition was removed as well, resulting in every template product BoM available.

Additionally, default Bom value selection when product and process type
are changed is fixed as well, because it wasn't taking in account
product variant management.

This commit fixes these problems together.