### PR TITLE
[15.0][ADD] mrp_location_custom

### DIFF
--- a/mrp_location_custom/__init__.py
+++ b/mrp_location_custom/__init__.py
@@ -1,0 +1,1 @@
+from . import models

--- a/mrp_location_custom/__manifest__.py
+++ b/mrp_location_custom/__manifest__.py
@@ -1,0 +1,14 @@
+{
+    'name': 'MRP - Custom source location per manufacturing order',
+    'version': '15.0.1.0.0',
+    'category': 'Manufacturing',
+    'summary': 'Assigns a dedicated Pre-Production location to each manufacturing order.',
+    'depends': ['mrp'],
+    'data': [
+        'views/stock_picking_type_views.xml',
+        'views/mrp_production_views.xml',
+    ],
+    'license': 'LGPL-3',
+    'installable': True,
+    'auto_install': False,
+}

--- a/mrp_location_custom/models/__init__.py
+++ b/mrp_location_custom/models/__init__.py
@@ -1,0 +1,2 @@
+from . import stock_picking_type
+from . import mrp_production

--- a/mrp_location_custom/models/mrp_production.py
+++ b/mrp_location_custom/models/mrp_production.py
@@ -82,6 +82,7 @@ class MrpProduction(models.Model):
                     'custom_location_src_id': custom_loc.id,
                     'location_src_id': custom_loc.id,
                 })
+                # production.move_raw_ids.write({'location_id': custom_loc.id})
 
         return production
 
@@ -119,6 +120,9 @@ class MrpProduction(models.Model):
                     'custom_location_src_id': custom_loc.id,
                     'location_src_id': custom_loc.id,
                 })
+                # TODO make the same at other cases
+                # production.move_raw_ids.write({'location_id': custom_loc.id})
+
 
         # --- Case 2: no longer requires custom location -------------------------
         to_remove = affected.filtered(
@@ -207,6 +211,7 @@ class MrpProduction(models.Model):
                 and m.state not in ('done', 'cancel')
             )
             if upstream_to_fix:
+                upstream_to_fix.picking_id.write({'location_dest_id': custom_loc.id})
                 upstream_to_fix.write({'location_dest_id': custom_loc.id})
                 upstream_to_fix.mapped('move_line_ids').write(
                     {'location_dest_id': custom_loc.id}

--- a/mrp_location_custom/models/mrp_production.py
+++ b/mrp_location_custom/models/mrp_production.py
@@ -40,7 +40,7 @@ class MrpProduction(models.Model):
         if not pbm_location:
             return False
 
-        location_name = self.name or _('New manufacturing order')
+        location_name = (self.name or _('New manufacturing order')).replace('/', '-')
         return self.env['stock.location'].create({
             'name': location_name,
             'location_id': pbm_location.id,
@@ -159,6 +159,58 @@ class MrpProduction(models.Model):
                     'custom_location_src_id': custom_loc.id,
                     'location_src_id': custom_loc.id,
                 })
+
+        return result
+
+    def action_confirm(self):
+        """After standard confirmation, ensure both sides of the Pre-Production
+        handoff point to the per-order custom location instead of the generic
+        pbm_loc_id of the warehouse.
+
+        Two corrections are needed:
+
+        1. move_raw_ids (consumption moves of the MO) — their location_id may
+           have been reset to the generic pbm_loc_id by Odoo's own onchange on
+           picking_type_id, which overwrites location_src_id with the operation
+           type's default before the moves are created.  We fix location_id on
+           those moves (and their move_line_ids) so the MO consumes from the
+           right place.
+
+        2. move_orig_ids of each raw move (the 'Pick Components' moves) — the
+           pull rule pbm_mto_pull_id stamps location_dest_id = pbm_loc_id on
+           every move it generates, regardless of what the consuming move
+           actually declares.  We fix location_dest_id so the picking delivers
+           to the same custom location the MO will consume from.
+        """
+        result = super().action_confirm()
+
+        for production in self.filtered(lambda p: p.custom_location_src_id):
+            custom_loc = production.custom_location_src_id
+            pbm_loc = production._get_warehouse_pbm_location()
+            if not pbm_loc:
+                continue
+
+            # --- 1. Raw moves (consumption): fix location_id ----------------
+            raw_to_fix = production.move_raw_ids.filtered(
+                lambda m: m.location_id.id == pbm_loc.id
+                and m.state not in ('done', 'cancel')
+            )
+            if raw_to_fix:
+                raw_to_fix.write({'location_id': custom_loc.id})
+                raw_to_fix.mapped('move_line_ids').write(
+                    {'location_id': custom_loc.id}
+                )
+
+            # --- 2. Upstream moves (Pick Components): fix location_dest_id --
+            upstream_to_fix = production.move_raw_ids.mapped('move_orig_ids').filtered(
+                lambda m: m.location_dest_id.id == pbm_loc.id
+                and m.state not in ('done', 'cancel')
+            )
+            if upstream_to_fix:
+                upstream_to_fix.write({'location_dest_id': custom_loc.id})
+                upstream_to_fix.mapped('move_line_ids').write(
+                    {'location_dest_id': custom_loc.id}
+                )
 
         return result
 

--- a/mrp_location_custom/models/mrp_production.py
+++ b/mrp_location_custom/models/mrp_production.py
@@ -1,0 +1,212 @@
+from odoo import api, fields, models, _
+
+
+class MrpProduction(models.Model):
+    _inherit = 'mrp.production'
+
+    custom_location_src_id = fields.Many2one(
+        comodel_name='stock.location',
+        string='Custom source location',
+        copy=False,
+        help=(
+            'Pre-Production location created specifically for this manufacturing order. '
+            'Generated automatically on creation when the operation type has '
+            '"Custom source location per manufacturing order" enabled.'
+        ),
+    )
+
+    # -------------------------------------------------------------------------
+    # Helpers
+    # -------------------------------------------------------------------------
+
+    def _get_warehouse_pbm_location(self):
+        """Return the Pre-Production location (pbm_loc_id) of the warehouse
+        linked to this order's operation type, or False if not applicable."""
+        self.ensure_one()
+        warehouse = self.picking_type_id.warehouse_id
+        if warehouse and warehouse.pbm_loc_id:
+            return warehouse.pbm_loc_id
+        return False
+
+    def _picking_type_uses_custom_location(self):
+        """Return True if the current operation type requires a custom source location."""
+        self.ensure_one()
+        return bool(self.picking_type_id.mrp_custom_src_location)
+
+    def _create_custom_src_location(self):
+        """Create a child location under pbm_loc_id and return it."""
+        self.ensure_one()
+        pbm_location = self._get_warehouse_pbm_location()
+        if not pbm_location:
+            return False
+
+        location_name = self.name or _('New manufacturing order')
+        return self.env['stock.location'].create({
+            'name': location_name,
+            'location_id': pbm_location.id,
+            'usage': 'internal',
+            'active': True,
+            'company_id': self.company_id.id,
+            'comment': _(
+                'Custom Pre-Production location for manufacturing order %s'
+            ) % location_name,
+        })
+
+    def _archive_custom_src_location(self):
+        """Archive the custom location if it exists and carries no stock."""
+        self.ensure_one()
+        loc = self.custom_location_src_id
+        if not loc:
+            return
+        has_stock = self.env['stock.quant'].search_count([
+            ('location_id', '=', loc.id),
+            ('quantity', '!=', 0),
+        ])
+        if not has_stock:
+            loc.write({'active': False})
+
+    # -------------------------------------------------------------------------
+    # ORM overrides
+    # -------------------------------------------------------------------------
+
+    @api.model
+    def create(self, vals):
+        # Call super first so the sequence name (e.g. WH/MO/00001) is already set
+        # before we use it as the location name.
+        production = super().create(vals)
+
+        if production._picking_type_uses_custom_location():
+            custom_loc = production._create_custom_src_location()
+            if custom_loc:
+                production.write({
+                    'custom_location_src_id': custom_loc.id,
+                    'location_src_id': custom_loc.id,
+                })
+
+        return production
+
+    def write(self, vals):
+        # Capture pre-write state for draft orders when the operation type changes.
+        picking_type_changed = 'picking_type_id' in vals
+        pre_state = {}
+        if picking_type_changed:
+            for production in self.filtered(lambda p: p.state == 'draft'):
+                pre_state[production.id] = {
+                    'had_custom': production._picking_type_uses_custom_location(),
+                    'custom_location_src_id': production.custom_location_src_id.id,
+                    'pbm_loc_id': (
+                        production._get_warehouse_pbm_location().id
+                        if production._get_warehouse_pbm_location() else False
+                    ),
+                }
+
+        result = super().write(vals)
+
+        if not (picking_type_changed and pre_state):
+            return result
+
+        affected = self.filtered(lambda p: p.id in pre_state)
+
+        # --- Case 1: now requires custom location, previously did not -----------
+        to_create = affected.filtered(
+            lambda p: not pre_state[p.id]['had_custom']
+            and p._picking_type_uses_custom_location()
+        )
+        for production in to_create:
+            custom_loc = production._create_custom_src_location()
+            if custom_loc:
+                production.write({
+                    'custom_location_src_id': custom_loc.id,
+                    'location_src_id': custom_loc.id,
+                })
+
+        # --- Case 2: no longer requires custom location -------------------------
+        to_remove = affected.filtered(
+            lambda p: pre_state[p.id]['had_custom']
+            and not p._picking_type_uses_custom_location()
+        )
+        for production in to_remove:
+            production._archive_custom_src_location()
+            default_src = (
+                production.picking_type_id.default_location_src_id
+                or production.picking_type_id.warehouse_id.lot_stock_id
+            )
+            production.write({
+                'custom_location_src_id': False,
+                'location_src_id': default_src.id if default_src else False,
+            })
+
+        # --- Case 3: both types use custom location but warehouse changed -------
+        to_relocate = affected.filtered(
+            lambda p: pre_state[p.id]['had_custom']
+            and p._picking_type_uses_custom_location()
+            and p._get_warehouse_pbm_location()
+            and pre_state[p.id]['pbm_loc_id'] != p._get_warehouse_pbm_location().id
+        )
+        for production in to_relocate:
+            old_loc = self.env['stock.location'].browse(
+                pre_state[production.id]['custom_location_src_id']
+            )
+            has_stock = self.env['stock.quant'].search_count([
+                ('location_id', '=', old_loc.id),
+                ('quantity', '!=', 0),
+            ])
+            if not has_stock:
+                old_loc.write({'active': False})
+            custom_loc = production._create_custom_src_location()
+            if custom_loc:
+                production.write({
+                    'custom_location_src_id': custom_loc.id,
+                    'location_src_id': custom_loc.id,
+                })
+
+        return result
+
+    # -------------------------------------------------------------------------
+    # Onchange for UX
+    # -------------------------------------------------------------------------
+
+    @api.onchange('picking_type_id')
+    def _onchange_picking_type_custom_location(self):
+        if self.state != 'draft':
+            return
+
+        now_uses_custom = self._picking_type_uses_custom_location()
+        had_custom = bool(self.custom_location_src_id)
+
+        if not had_custom and now_uses_custom:
+            return {
+                'warning': {
+                    'title': _('Custom source location'),
+                    'message': _(
+                        'On save, a dedicated Pre-Production location will be created '
+                        'automatically for this order under warehouse "%s".'
+                    ) % self.picking_type_id.warehouse_id.name,
+                }
+            }
+
+        if had_custom and not now_uses_custom:
+            return {
+                'warning': {
+                    'title': _('Custom source location'),
+                    'message': _(
+                        'On save, the custom source location "%s" will be archived '
+                        '(provided it holds no stock) and the field will be cleared.'
+                    ) % self.custom_location_src_id.display_name,
+                }
+            }
+
+        if had_custom and now_uses_custom:
+            old_pbm = self.custom_location_src_id.location_id
+            new_pbm = self._get_warehouse_pbm_location()
+            if old_pbm and new_pbm and old_pbm.id != new_pbm.id:
+                return {
+                    'warning': {
+                        'title': _('Custom source location'),
+                        'message': _(
+                            'The warehouse has changed. On save, the current custom source '
+                            'location will be archived and a new one will be created '
+                            'under "%s".'
+                        ) % new_pbm.display_name,
+                    }
+                }

--- a/mrp_location_custom/models/stock_picking_type.py
+++ b/mrp_location_custom/models/stock_picking_type.py
@@ -1,0 +1,54 @@
+from odoo import api, fields, models
+
+
+class StockPickingType(models.Model):
+    _inherit = 'stock.picking.type'
+
+    is_pbm_manufacture_type = fields.Boolean(
+        string='Is PBM Manufacture Type',
+        compute='_compute_is_pbm_manufacture_type',
+    )
+
+    mrp_custom_src_location = fields.Boolean(
+        string='Custom source location per manufacturing order',
+        compute='_compute_mrp_custom_src_location',
+        store=True,
+        readonly=False,
+        help=(
+            'When enabled, each new manufacturing order created with this operation type '
+            'will automatically generate a child location under the warehouse Pre-Production '
+            'area, assigned as the exclusive source location for that order.\n\n'
+            'Only applicable to manufacturing operation types in warehouses configured '
+            'with two or three-step manufacturing (pbm / pbm_sam). '
+            'Automatically disabled if the warehouse manufacturing steps change.'
+        ),
+    )
+
+    @api.depends('code', 'warehouse_id', 'warehouse_id.manufacture_steps')
+    def _compute_is_pbm_manufacture_type(self):
+        pbm = self.filtered(
+            lambda pt: pt.code == 'mrp_operation'
+            and pt.warehouse_id.manufacture_steps in ('pbm', 'pbm_sam')
+        )
+        pbm.is_pbm_manufacture_type = True
+        (self - pbm).is_pbm_manufacture_type = False
+
+    @api.depends('is_pbm_manufacture_type')
+    def _compute_mrp_custom_src_location(self):
+        # When the operation type is no longer pbm-compatible, force the flag to False.
+        # Records that still qualify are left untouched (their stored value is kept).
+        non_pbm = self.filtered(lambda pt: not pt.is_pbm_manufacture_type)
+        non_pbm.mrp_custom_src_location = False
+
+    @api.onchange('mrp_custom_src_location')
+    def _onchange_mrp_custom_src_location(self):
+        if not self.mrp_custom_src_location:
+            return {
+                'warning': {
+                    'title': 'Warning',
+                    'message': (
+                        'Disabling this option will not affect manufacturing orders that '
+                        'have already been created. Only new orders will be impacted.'
+                    ),
+                }
+            }

--- a/mrp_location_custom/views/mrp_production_views.xml
+++ b/mrp_location_custom/views/mrp_production_views.xml
@@ -1,0 +1,22 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="mrp_production_form_inherit_custom_location" model="ir.ui.view">
+        <field name="name">mrp.production.form.inherit.custom.location</field>
+        <field name="model">mrp.production</field>
+        <field name="inherit_id" ref="mrp.mrp_production_form_view"/>
+        <field name="arch" type="xml">
+
+            <xpath expr="//field[@name='location_src_id']" position="after">
+                <field
+                    name="custom_location_src_id"
+                    string="Custom source location"
+                    readonly="1"
+                    attrs="{'invisible': [('custom_location_src_id', '=', False)]}"
+                />
+            </xpath>
+
+        </field>
+    </record>
+
+</odoo>

--- a/mrp_location_custom/views/stock_picking_type_views.xml
+++ b/mrp_location_custom/views/stock_picking_type_views.xml
@@ -4,7 +4,7 @@
     <record id="action_picking_type_form_inherit_custom_location" model="ir.ui.view">
         <field name="name">stock.picking.type.form.inherit.mrp.custom.location</field>
         <field name="model">stock.picking.type</field>
-        <field name="inherit_id" ref="stock.action_picking_type_form"/>
+        <field name="inherit_id" ref="stock.view_picking_type_form"/>
         <field name="arch" type="xml">
 
             <xpath expr="//field[@name='default_location_src_id']" position="after">

--- a/mrp_location_custom/views/stock_picking_type_views.xml
+++ b/mrp_location_custom/views/stock_picking_type_views.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<odoo>
+
+    <record id="action_picking_type_form_inherit_custom_location" model="ir.ui.view">
+        <field name="name">stock.picking.type.form.inherit.mrp.custom.location</field>
+        <field name="model">stock.picking.type</field>
+        <field name="inherit_id" ref="stock.action_picking_type_form"/>
+        <field name="arch" type="xml">
+
+            <xpath expr="//field[@name='default_location_src_id']" position="after">
+                <field name="is_pbm_manufacture_type" invisible="1"/>
+                <field
+                    name="mrp_custom_src_location"
+                    attrs="{
+                        'invisible': [('is_pbm_manufacture_type', '=', False)],
+                        'readonly':  [('is_pbm_manufacture_type', '=', False)]
+                    }"
+                    widget="boolean_toggle"
+                />
+            </xpath>
+
+        </field>
+    </record>
+
+</odoo>


### PR DESCRIPTION
Adds a custom per-manufacture order location for 2-step and 3-step manufacture orders.

This location replaces standard Pre-Production one and is only used for each MO and will be archived when MO is completely finished

TODO

* [ ] Test in general, default normal case
* [ ] Test warehouse change when MO is at draft state
* [ ] archive location when MO is finished.
* [ ] `es` translations